### PR TITLE
Fix Lighthouse errors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,14 @@
 <meta charset="UTF-8">
   <head>
 	<title>Laura Eberly's Website</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="description" content="Laura Eberly is an accessibility enthusiast and writer.">
 	<link href='https://fonts.googleapis.com/css?family=Cutive+Mono' rel='stylesheet'>
 	<link href='https://fonts.googleapis.com/css?family=Ubuntu' rel='stylesheet'>
     <style>
 	  h1, h2 {font-family: 'Cutive Mono'; text-align:center; color:navy;}
 	  ul {font-family: 'Ubuntu'; list-style-type: none; padding: 0; text-align:center; color:navy} 
-	  li {font-family: 'Ubuntu'; margin: 10px 0; text-align:center; color:navy}
+	  li {font-family: 'Ubuntu'; margin: 10px 0; padding: 8px; text-align:center; color:navy}
 	  p {font-family: 'Ubuntu'; text-align:center; color:navy;}
 	  
 	  #daffodil_left{


### PR DESCRIPTION
Adding the viewport meta tag makes the page resize appropriate only mobile devices. The absence of this tag was causing the font size audit to fail.

I also added a little padding to the links in the lists to make the tap sizes audit happy.

And I added a description to make the meta description audit happy :)